### PR TITLE
Release update thread pool implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(qLib LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 find_package (Threads)
+FIND_PACKAGE(Boost COMPONENTS program_options thread system REQUIRED)
 
 include_directories(
     .
@@ -27,5 +28,7 @@ file (GLOB TEST_SRC test/*.cpp)
 add_executable(test-qlib ${TEST_SRC})
 target_link_libraries(test-qlib PRIVATE
     fmt-header-only
+    boost_system
+    boost_thread
     ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = qLib
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.0
+PROJECT_NUMBER         = 0.1.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/qlib.h
+++ b/qlib.h
@@ -12,6 +12,7 @@
 #include "default_decs.h"
 #include "logger.h"
 #include "strutils.h"
+#include "thread.h"
 #include "thread_pool.h"
 
 /**

--- a/thread.h
+++ b/thread.h
@@ -1,0 +1,74 @@
+/**
+ * \file thread.h
+ * Basic thread definitions for qLib
+ * 
+ * \author Igor Siemienowicz
+ * 
+ * \copyright Copyright Igor Siemienowicz 2018 Distributed under the Boost
+ * Software License, Version 1.0. (See accompanying file ../LICENSE_1_0.txt
+ * or copy at https://www.boost.org/LICENSE_1_0.txt
+ */
+
+#define BOOST_THREAD_PROVIDES_FUTURE
+#include <boost/thread.hpp>
+
+#ifndef _qlib_thread_h_included
+#define _qlib_thread_h_included
+
+namespace qlib {
+
+/**
+ * \brief The main qLib mutex type
+ */
+using shared_mutex = boost::shared_mutex;
+
+/**
+ * \brief A non-exclusive lock for reading a resource
+ */
+using write_lock = boost::unique_lock<shared_mutex>;
+
+/**
+ * \brief An exclusive lock for writing to a resource
+ */
+using read_lock = boost::shared_lock<shared_mutex>;
+
+/**
+ * \brief A standard (non-shared) mutex
+ */
+using mutex = boost::mutex;
+
+/**
+ * \brief A standard lock guard on a standard mutex
+ */
+using lock = boost::unique_lock<mutex>;
+
+/**
+ * \brief The condition variable type used by qLib
+ */
+using condition_variable = boost::condition_variable;
+
+/**
+ * \brief Asynchronous future type used by qLib
+ *
+ * \tparam The return type of the future (returned by the `get` method)
+ */
+template <typename R> using future = boost::future<R>;
+
+/**
+ * \brief Packaged task type used by qLib
+ *
+ * \tparam R The type of the task function
+ *
+ * \tparam Args The argument types for the task function
+ */
+template <typename R, typename... Args>
+using packaged_task = boost::packaged_task<R, Args...>;
+
+/**
+ * \brief The thread type used by qLib
+ */
+using thread = boost::thread;
+
+}   // end qlib namespace
+
+#endif

--- a/thread_pool.h
+++ b/thread_pool.h
@@ -9,17 +9,14 @@
  * or copy at https://www.boost.org/LICENSE_1_0.txt
  */
 
-#include <condition_variable>
 #include <functional>
-#include <future>
 #include <memory>
-#include <mutex>
 #include <queue>
 #include <stdexcept>
-#include <thread>
 #include <vector>
 
 #include "default_decs.h"
+#include "thread.h"
 
 #ifndef _qlib_thread_pool_h_included
 #define _qlib_thread_pool_h_included
@@ -53,17 +50,21 @@ namespace qlib {
  * // The first one sets an external falg
  * bool test_flag = false;
  * auto result1 = tp.enqueue([&test_flag]() { test_flag = true; });
+ *     // result1 is type qlib::future<void>
  *
  * // The second task takes no arguments, but returns a result
  * auto result2 = tp.enqueue([]() { return std::string("abc"); });
+ *     // result2 is type qlib::future<std::string>
  *
  * // This task uses a predefined lambda that adds two integers. Note that
  * // the call to enqueue the task takes the arguments as well.
  * auto my_fn = [](int a, int b) { return a+b; };
  * auto result3 = tp.enqueue(my_fn, 2, 3);
+ *     // result3 is type qlib::future<int>
  *
  * // This task throws an exception!
  * auto result4 = tp.enqueue([]() { throw std::runtime_error("test"); });
+ *     // result4 is type qlib::future<void>
  *
  * // Four tasks now being executed...
  *
@@ -77,6 +78,8 @@ namespace qlib {
  * // task.
  * result4.get();
  * \endcode
+ *
+ * \todo Continuations have not been tested with the new Boost futures
  */
 class thread_pool final
 {
@@ -94,7 +97,7 @@ class thread_pool final
      * (defaults to the available hardware concurrency)
      */
     explicit thread_pool(
-            std::size_t num_threads = std::thread::hardware_concurrency()) :
+            std::size_t num_threads = thread::hardware_concurrency()) :
         m_workers()
         , m_tasks()
         , m_tasks_mtx()
@@ -115,7 +118,7 @@ class thread_pool final
 
                         // Wait until there is a task, or 'stop' has been
                         // raised.
-                        std::unique_lock<std::mutex> tasks_lck(m_tasks_mtx);
+                        lock tasks_lck(m_tasks_mtx);
                         m_tasks_cv.wait(
                             tasks_lck
                             , [this](void)
@@ -143,7 +146,7 @@ class thread_pool final
      */
     ~thread_pool(void)
     {
-        std::unique_lock<std::mutex> tasks_lck(m_tasks_mtx);
+        lock tasks_lck(m_tasks_mtx);
         m_stop = true;
         tasks_lck.unlock();
 
@@ -166,8 +169,8 @@ class thread_pool final
      *
      * \param args The arguments to the enqueued function
      *
-     * \return A `std::future` object that can be used to obtain the
-     * result of `fn`, or access any exception thrown
+     * \return A `future` object that can be used to obtain the result of
+     * `fn`, or access any exception thrown
      */
     template <typename F, typename... Args>
     auto enqueue(F&& fn, Args&&... args)
@@ -176,13 +179,13 @@ class thread_pool final
         // Package the task for executing
         using return_t = typename std::result_of<F(Args...)>::type;
 
-        auto task = std::make_shared<std::packaged_task<return_t(void)> >(
+        auto task = std::make_shared<packaged_task<return_t> >(
             std::bind(std::forward<F>(fn), std::forward<Args>(args)...));
 
-        std::future<return_t> result = task->get_future();
+        future<return_t> result = task->get_future();
 
         // Place the task in the queue and notify a sleeping thread
-        std::unique_lock<std::mutex> tasks_lck(m_tasks_mtx);
+        lock tasks_lck(m_tasks_mtx);
 
         if (m_stop)
             throw std::runtime_error(
@@ -201,7 +204,7 @@ class thread_pool final
     /**
      * \brief The collection of thread objects
      */
-    std::vector<std::thread> m_workers;
+    std::vector<thread> m_workers;
 
     /**
      * \brief The queue of tasks
@@ -211,12 +214,12 @@ class thread_pool final
     /**
      * \brief Mutex for synchronising task queue access
      */
-    std::mutex m_tasks_mtx;
+    mutex m_tasks_mtx;
 
     /**
      * \brief Condition variable for monitoring tasks queue status
      */
-    std::condition_variable m_tasks_cv;
+    condition_variable m_tasks_cv;
 
     /**
      * \brief Flag to signal that thread pool is being shut down


### PR DESCRIPTION
The `thread_pool` class is now based on Boost.Thread, which has more functionality, and supports the `wait_for_all` construct.